### PR TITLE
Fixed incorrectly lowercased unit test file refs

### DIFF
--- a/test/unit/core/api_test.js
+++ b/test/unit/core/api_test.js
@@ -2,8 +2,8 @@ var fs = require('fs');
 
 eval(fs.readFileSync('src/core/api.js').toString());
 eval(fs.readFileSync('src/core/utils.js').toString());
-eval(fs.readFileSync('src/core/uabeacon.js').toString());
-eval(fs.readFileSync('src/core/utmbeacon.js').toString());
+eval(fs.readFileSync('src/core/uaBeacon.js').toString());
+eval(fs.readFileSync('src/core/utmBeacon.js').toString());
 
 module.exports = {
     "API.parseBeacon": {


### PR DESCRIPTION
Two unit test file paths (`utmBeacon.js` and `uaBeacon.js`) were incorrectly cased which causes tests to fail if the build environment is sensitive to filename case.

Fix for #4.