### PR TITLE
Fix timing event beacon hint

### DIFF
--- a/src/core/api.js
+++ b/src/core/api.js
@@ -39,7 +39,7 @@ var GACoreAPI = (function() {
         } else if (beacon.type === 'pageview') {
             hint = beacon.documentPath;
         } else if (beacon.type === 'timing') {
-            hint = beacon.userTimings.category + ' / ' + beacon.userTimings.var + ' / ' + beacon.userTimings.value + 'ms';
+            hint = beacon.userTimings.category + ' / ' + beacon.userTimings.variable + ' / ' + beacon.userTimings.value + 'ms';
         }
         return hint;
     }


### PR DESCRIPTION
Fix `timing` events so it displays `variable` properly instead of `undefined`.

Before:

<img width="610" alt="screen shot 2015-10-06 at 16 26 44" src="https://cloud.githubusercontent.com/assets/228886/10313594/67ed8a84-6c48-11e5-8c3a-21fa9ef7c425.png">

After:

<img width="658" alt="screen shot 2015-10-06 at 16 25 34" src="https://cloud.githubusercontent.com/assets/228886/10313604/72927058-6c48-11e5-9830-a8dbd55a600e.png">

~~I bumped the `package.json` version but I can't build a proper extension dist as I don't have the certificate.~~