### PR TITLE
Firefox devtools path fixes

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -43,6 +43,7 @@ module.exports = function(grunt) {
             'src/firefox/chrome/tool.xul',
             'src/firefox/chrome/tool.js',
             'src/firefox/chrome/panel.js',
+            'src/firefox/chrome/resourceHelpers.jsm',
             'src/firefox/locale/**',
             'src/firefox/skin/**',
             'src/firefox/*'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gadebugger",
   "description": "A browser extension for debugging Google Analytics tracking code",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "http://github.com/keithclark/gadebugger",
   "author": {
     "name": "Keith Clark",

--- a/src/firefox/chrome/resourceHelpers.jsm
+++ b/src/firefox/chrome/resourceHelpers.jsm
@@ -1,0 +1,43 @@
+// Devtools paths changed in version 44 Firefox which will breakx GA Debugger.
+// This helper module provides methods for mapping new URLs to the one ones
+// (depending on the current version of Firefox.) It also provides methods for
+// injecting assets into an XUL document.
+//
+// ** This is a temporary fix and will remain here unitl the old versions are
+// phased out, at which point the min version for this extension will be changed
+// to 44 **
+
+'use strict';
+
+const { classes: Cc, interfaces: Ci, utils: Cu, results: Cr } = Components;
+
+this.EXPORTED_SYMBOLS = ['ResourceHelpers'];
+
+let FirefoxInfo = Cc['@mozilla.org/xre/app-info;1'].getService(Ci.nsIXULAppInfo),
+    FirefoxMajorVer = parseInt(FirefoxInfo.version),
+    ResourceHelpers = {
+        resolveUrl: resolveUrl,
+        insertStyleSheet: insertStyleSheet,
+        importModule: importModule
+    };
+
+function resolveUrl(url) {
+    if (FirefoxMajorVer < 44) {
+        url = url.replace('resource://devtools/client/shared/widgets/', 'resource:///modules/devtools/');
+        url = url.replace('chrome://devtools/content/shared/widgets/', 'chrome://browser/content/devtools/');
+        url = url.replace('chrome://devtools/content/', 'chrome://browser/content/');
+        url = url.replace('chrome://devtools/skin/', 'chrome://browser/skin/devtools/');
+    } else if (FirefoxInfo.version === '44.0a2') {
+        url = url.replace('chrome://devtools/skin/', 'chrome://devtools/skin/themes/');
+    }
+    return url;
+}
+
+function insertStyleSheet(url, doc) {
+    var pi = doc.createProcessingInstruction('xml-stylesheet', 'href="' + resolveUrl(url) + '" type="text/css"');
+    doc.insertBefore(pi, doc.firstChild);
+}
+
+function importModule(url, scope) {
+    Cu.import(resolveUrl(url), scope);
+}

--- a/src/firefox/chrome/tool.js
+++ b/src/firefox/chrome/tool.js
@@ -15,11 +15,17 @@ const EVENTS = {
 const RE_ALPHA_CHARS = /[^a-z]/gi;
 const RE_NUMBERIC_CHARS = /[^0-9.]/g;
 
-
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource:///modules/devtools/SideMenuWidget.jsm');
-Cu.import('resource:///modules/devtools/ViewHelpers.jsm');
-Cu.import('resource:///modules/devtools/VariablesView.jsm');
+Cu.import('chrome://gadebugger/content/resourceHelpers.jsm')
+
+ResourceHelpers.importModule('resource://devtools/client/shared/widgets/SideMenuWidget.jsm', this);
+ResourceHelpers.importModule('resource://devtools/client/shared/widgets/ViewHelpers.jsm', this);
+ResourceHelpers.importModule('resource://devtools/client/shared/widgets/VariablesView.jsm', this);
+
+ResourceHelpers.insertStyleSheet('chrome://devtools/skin/common.css', document);
+ResourceHelpers.insertStyleSheet('chrome://devtools/skin/splitview.css', document);
+ResourceHelpers.insertStyleSheet('chrome://devtools/skin/widgets.css', document);
+ResourceHelpers.insertStyleSheet('chrome://devtools/content/shared/widgets/widgets.css', document);
 
 XPCOMUtils.defineLazyModuleGetter(this, 'EventEmitter', 'resource://gre/modules/devtools/event-emitter.js');
 XPCOMUtils.defineLazyModuleGetter(this, 'promise', 'resource://gre/modules/commonjs/sdk/core/promise.js', 'Promise');

--- a/src/firefox/chrome/tool.xul
+++ b/src/firefox/chrome/tool.xul
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet href="chrome://browser/skin/" type="text/css"?>
-<?xml-stylesheet href="chrome://browser/skin/devtools/common.css" type="text/css"?>
-<?xml-stylesheet href="chrome://browser/skin/devtools/splitview.css" type="text/css"?>
-<?xml-stylesheet href="chrome://browser/skin/devtools/widgets.css" type="text/css"?>
-<?xml-stylesheet href="chrome://browser/content/devtools/widgets.css" type="text/css"?>
 <?xml-stylesheet href="chrome://gadebugger/skin/style.css" type="text/css"?>
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" xmlns:html="http://www.w3.org/1999/xhtml">
 
-  <script type="application/javascript;version=1.8" src="chrome://browser/content/devtools/theme-switching.js" />
+  <script type="application/javascript;version=1.8" src="chrome://devtools/content/shared/theme-switching.js" /><!-- Firefox 44+ -->
+  <script type="application/javascript;version=1.8" src="chrome://browser/content/devtools/theme-switching.js" /><!-- Firefox <44 -->
   <script src="tool.js" />
   <script src="core.js" />
 

--- a/src/firefox/install.rdf
+++ b/src/firefox/install.rdf
@@ -14,7 +14,7 @@
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>29.0a1</em:minVersion>
-        <em:maxVersion>42.0</em:maxVersion>
+        <em:maxVersion>45.0</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:type>2</em:type>


### PR DESCRIPTION
In Firefox 44 the paths to internal devtools assets changed. GA Debugger uses several devtools modules and stylesheets to ensure the UI looks and behaves identically to the other built-in tools. 

This fix introduces a set of helpers for mapping the new asset urls (defined in FF44) to the old format, allowing GA debugger to work in all current versions of Firefox.

Unfortunately, the `theme-switching.js` file in `tool.xul` could not be loaded dynamically using a helper so both the new and old urls have been included with `<script>` elements. Firefox will try and load both these assets even though only one can ever exist — triggering a browser console warning.

Once pre-44 versions of Firefox have phased out the helpers should be removed and extension `install.rdf` updated to set FF44 as a minimum requirement.

This fix bumps GA Debugger to 2.1.1, but only Firefox users will get this version.

This PR fixes issue #28