### PR TITLE
Fix duplicate beacon error in Chrome

### DIFF
--- a/src/chrome/js/api.js
+++ b/src/chrome/js/api.js
@@ -55,7 +55,9 @@ var GADebuggerAPI = (function() {
     });
 
     function requestHandler(request) {
-        process(request.request);
+        if (request.response.status === 200) {
+            process(request.request);
+        }
     }
 
     document.addEventListener('change', function (e) {


### PR DESCRIPTION
Fix for #31

This PR addresses an issue in Chrome where beacons are duplicate because [HTTP Strict Transport Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) (HSTS) redirects HTTP requests to HTTPS using an internal 307 redirect. This change will ensure beacons will only appear in the log if the GA beacon HTTP request returns a 200 status code.
