### PR TITLE
Hotfix for breaking changes in Firefox 51

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gadebugger",
   "description": "A browser extension for debugging Google Analytics tracking code",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "homepage": "http://github.com/keithclark/gadebugger",
   "author": {
     "name": "Keith Clark",

--- a/src/firefox/bootstrap.js
+++ b/src/firefox/bootstrap.js
@@ -4,7 +4,7 @@ const { classes: Cc, interfaces: Ci, utils: Cu, results: Cr } = Components;
 
 Cu.import('resource://gre/modules/Services.jsm');
 Cu.import('resource://gre/modules/XPCOMUtils.jsm');
-Cu.import('resource:///modules/devtools/gDevTools.jsm');
+Cu.import('resource://devtools/client/framework/gDevTools.jsm');
 
 XPCOMUtils.defineLazyGetter(this, 'osString', () => Cc['@mozilla.org/xre/app-info;1'].getService(Ci.nsIXULRuntime).OS);
 XPCOMUtils.defineLazyGetter(this, 'toolStrings', () => Services.strings.createBundle('chrome://gadebugger/locale/strings.properties'));

--- a/src/firefox/chrome/resourceLoader.js
+++ b/src/firefox/chrome/resourceLoader.js
@@ -30,14 +30,7 @@ if (appMajorVer >= 48) {
 
 ResourceLoader.require = function (url) {
 
-    if (url === 'devtools/client/shared/l10n') {
-        // Prior to v48, the localization helpers were in ViewHelpers.jsm
-        if (appMajorVer < 48) {
-            return {
-                LocalizationHelper: ResourceLoader.require('devtools/client/shared/widgets/view-helpers').ViewHelpers.L10N
-            }
-        }
-    } else if (url === 'devtools/client/shared/widgets/view-helpers') {
+    if (url === 'devtools/client/shared/widgets/view-helpers') {
         if (appMajorVer < 44) {
             // Prior to v44, ViewHelpers was in a different directory. (see: https://bugzil.la/912121)
             url = 'resource:///modules/devtools/ViewHelpers.jsm';

--- a/src/firefox/chrome/tool.js
+++ b/src/firefox/chrome/tool.js
@@ -2,8 +2,6 @@
 
 const { classes: Cc, interfaces: Ci, utils: Cu, results: Cr } = Components;
 
-const STRINGS_URI = 'chrome://gadebugger/locale/strings.properties';
-
 const EVENTS = {
   NETWORK_EVENT: 'networkEvent',
   NETWORK_EVENT_UPDATE: 'networkEventUpdate',
@@ -21,7 +19,6 @@ const appVersion = ResourceLoader.getAppMajorVersion();
 const {Heritage, WidgetMethods, ViewHelpers} = ResourceLoader.require('devtools/client/shared/widgets/view-helpers');
 const {SideMenuWidget} = ResourceLoader.require('resource://devtools/client/shared/widgets/SideMenuWidget.jsm');
 const {VariablesView} = ResourceLoader.require('resource://devtools/client/shared/widgets/VariablesView.jsm');
-const {LocalizationHelper} = ResourceLoader.require('devtools/client/shared/l10n');
 const EventEmitter = ResourceLoader.require('devtools/shared/event-emitter');
 const promise = ResourceLoader.require('promise');
 
@@ -575,7 +572,14 @@ let BeaconPropertiesView = {
 /**
  * Localization convenience methods.
  */
-let L10N = new LocalizationHelper(STRINGS_URI);
+let L10N = function() {
+    const stringsBundle = document.getElementById("string-bundle");
+    return {
+        getStr: function(x)  {
+            return stringsBundle.getString(x)
+        }
+    }
+}
 
 /**
  * Convenient way of emitting events from the panel window.

--- a/src/firefox/chrome/tool.xul
+++ b/src/firefox/chrome/tool.xul
@@ -3,6 +3,10 @@
 <?xml-stylesheet href="chrome://gadebugger/skin/style.css" type="text/css"?>
 <window xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul" xmlns:html="http://www.w3.org/1999/xhtml">
 
+ <stringbundleset id="stringbundleset">
+   <stringbundle id="string-bundle" src="chrome://gadebugger/locale/strings.properties"/>
+ </stringbundleset>
+
   <script type="application/javascript;version=1.8" src="chrome://devtools/content/shared/theme-switching.js" /><!-- Firefox 44+ -->
   <script type="application/javascript;version=1.8" src="chrome://browser/content/devtools/theme-switching.js" /><!-- Firefox <44 -->
   <script src="tool.js" />


### PR DESCRIPTION
Fix for #37

This PR fixes a breaking change caused by the evolution of Firefox devtools. The path to the localisation helpers (`l10n.js`) has changed. Unfortunately, referencing the new path did not fix the issue because the helper no longer seems to resolve `chrome://` urls correctly, which means the `strings.properties` file never loads, breaking GA debugger.

The PR replaces the L10N helpers with a `<stringbundleset>`. 