### PR TITLE
Fix Firefox bug which prevents some beacon inspector panels from working

### DIFF
--- a/src/firefox/chrome/tool.js
+++ b/src/firefox/chrome/tool.js
@@ -575,6 +575,9 @@ let BeaconPropertiesView = {
 let L10N = (function() {
     const stringsBundle = document.getElementById("string-bundle");
     return {
+        getFormatStr: function (name, value) {
+            return L10N.getStr(name).replace('%S', value);
+        },
         getStr: function(x)  {
             return stringsBundle.getString(x)
         }


### PR DESCRIPTION
This PR fixes issue #39, which prevents some panels in the beacon inspector from working in Firefox due to a missing method on the `L10N` object.