### PR TITLE
Add support for 'screenview' event

### DIFF
--- a/src/chrome/css/gadebugger.css
+++ b/src/chrome/css/gadebugger.css
@@ -51,7 +51,8 @@ body > .splitview {
     padding-left: 25px;
 }
 
-.beacon--pageview {
+.beacon--pageview,
+.beacon--screenview {
     background-image: url(../img/beacon-pageview.png);
 }
 

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -56,6 +56,8 @@ var GACoreAPI = (function() {
             }
         } else if (beacon.type === 'pageview') {
             hint = beacon.documentPath;
+        } else if (beacon.type === 'screenview') {
+            hint = beacon.screenName;
         } else if (beacon.type === 'timing') {
             hint = beacon.userTimings.category + ' / ' + beacon.userTimings.variable + ' / ' + beacon.userTimings.value + 'ms';
             if (beacon.userTimings.label) {

--- a/src/firefox/skin/style.css
+++ b/src/firefox/skin/style.css
@@ -35,7 +35,8 @@
     padding-left: 20px;
 }
 
-.beacon--pageview {
+.beacon--pageview,
+.beacon--screenview {
     background-image: url(beacon-pageview.png);
 }
 


### PR DESCRIPTION
This PR adds support for "screenview" events.
See
https://developers.google.com/analytics/devguides/collection/gtagjs/screens
https://developers.google.com/analytics/devguides/collection/analyticsjs/screens

In the CSS, I saw [more references to `.beacon--pageview`](https://github.com/keithclark/gadebugger/blob/4a553d305f6fe9781c6ae71f49b896399f02fdc4/src/chrome/css/gadebugger.css#L80-L90).
I was not able to fix them, but it's probably a piece of cake for a CSS wizard.